### PR TITLE
Adding mathEx.py with test

### DIFF
--- a/ml/common/mathEx.py
+++ b/ml/common/mathEx.py
@@ -1,0 +1,505 @@
+"""
+mathEX.py
+@author: Jinchi Zhang
+@email: jizjiz148148@gmail.com
+
+Math-related functions, extensions.
+"""
+import numpy as np
+from ml.utils.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+def change_to_multi_class(y):
+    """
+    change the input prediction y to array-wise multi_class classifiers.
+
+    @param y:input prediction y, numpy arrays
+    @return: array-wise multi_class classifiers
+    """
+    if not isinstance(y, np.ndarray) or y.ndim <= 1:
+        LOGGER.info('Input is not an np.ndarray, adding default value...')
+        y = np.array([[0]])
+
+    m = y.shape[1]
+    num_of_fields = int(y.max()) + 1
+    multi_class_y = np.zeros([num_of_fields, m])
+
+    for i in range(m):
+        label = y[0, i]
+        print(type(label))
+        if isinstance(label, np.int64) and label >= 0:
+            multi_class_y[label, i] = 1
+        else:
+            multi_class_y[0, i] = 1
+
+    return multi_class_y
+
+
+def compute_cost(al, y):
+    """
+    compute costs between output results and actual results y. NEEDS TO BE MODIFIED.
+
+    @param al: output results, numpy arrays
+    @param y: actual result, numpy arrays
+    @return: cost, floats
+    """
+    if isinstance(al, np.float) or isinstance(al, float) or isinstance(al, int):
+        al = np.array([[al]])
+    if isinstance(y, np.float) or isinstance(y, float) or isinstance(y, int):
+        y = np.array([[y]])
+    if not isinstance(al, np.ndarray) or not isinstance(y, np.ndarray) or not al.ndim > 1 or not y.ndim > 1:
+        LOGGER.info('Input is not an np.ndarray, adding default value...')
+        al = np.array([[0.5]])
+        y = np.array([[0.6]])
+
+    m = y.shape[1]
+
+    # Compute loss from aL and y.
+    cost = sum(sum((1. / m) * (-np.dot(y, np.log(al).T) - np.dot(1 - y, np.log(1 - al).T))))
+
+    cost = np.squeeze(cost)
+
+    assert (cost.shape == ())
+
+    return cost
+
+
+def compute_cost_with_l2_regularization(al, y, parameters, lambd):
+    """
+    compute costs with L2 regularization, uses the original cost function.
+
+    @param al: results AL, numpy arrays
+    @param y: actual results y, numpy arrays
+    @param parameters: parameters got from forward propagation, dictionaries
+    @param lambd: lambda for regularization, floats
+    @return: cost, floats
+    """
+    if isinstance(al, np.float) or isinstance(al, float) or isinstance(al, int):
+        al = np.array([[al]])
+    if isinstance(y, np.float) or isinstance(y, float) or isinstance(y, int):
+        y = np.array([[y]])
+    if not isinstance(al, np.ndarray) or not isinstance(y, np.ndarray) or not al.ndim > 1 or not y.ndim > 1:
+        LOGGER.info('Input is not an np.ndarray, adding default value...')
+        al = np.array([[0.5]])
+        y = np.array([[0.6]])
+
+    m = y.shape[1]
+    num_of_parameters = len(parameters) // 2
+    w_square_sum = 0
+
+    # adding up Ws
+    for i in range(num_of_parameters):
+        try:
+            w_square_sum += np.sum(np.square(parameters['W'+str(i+1)]))
+        except KeyError as ex:
+            LOGGER.info('Invalid parameter set')
+            raise ex
+
+    # compute regular costs
+    cross_entropy_cost = compute_cost(al, y)
+
+    # combine regular costs and regularization term
+    l2_regularization_cost = (lambd / (2 * m)) * w_square_sum
+
+    cost = cross_entropy_cost + l2_regularization_cost
+
+    return cost
+
+"""
+def initialize_parameters_deep_he(layer_dims):
+
+    initialization for deep learning with HE random algorithm to prevent fading & exploding gradients.
+
+    @param layer_dims: dimensions of layers, lists
+    @return: initialized parameters
+
+    np.random.seed(1)
+    parameters = {}
+    L = len(layer_dims)  # number of layers in the network
+
+    for l in range(1, L):
+
+        # initialized W with random and HE term
+        parameters['W' + str(l)] = np.random.randn(layer_dims[l], layer_dims[l - 1]) * np.sqrt(2 / layer_dims[l - 1])
+
+        parameters['b' + str(l)] = np.zeros((layer_dims[l], 1))
+
+        assert (parameters['W' + str(l)].shape == (layer_dims[l], layer_dims[l - 1]))
+        assert (parameters['b' + str(l)].shape == (layer_dims[l], 1))
+
+    return parameters
+"""
+
+"""
+def initialize_parameters_deep(layer_dims):
+
+    np.random.seed(1)
+    parameters = {}
+    L = len(layer_dims)  # number of layers in the network
+
+    for l in range(1, L):
+        parameters['W' + str(l)] = np.random.randn(layer_dims[l], layer_dims[l - 1])
+        parameters['b' + str(l)] = np.zeros((layer_dims[l], 1))
+
+        assert (parameters['W' + str(l)].shape == (layer_dims[l], layer_dims[l - 1]))
+        assert (parameters['b' + str(l)].shape == (layer_dims[l], 1))
+
+    return parameters
+"""
+
+
+def l_model_forward(x, parameters):
+    """
+    Forward propagation of deep learning.
+
+    @param x: input x, numpy arrays
+    @param parameters:
+    @return: output aL and caches for following calculations, numpy arrays and indexes
+    """
+    caches = []
+    a = x
+    l = len(parameters) // 2  # number of layers in the neural network
+
+    # Implement [LINEAR -> RELU]*(L-1). Add "cache" to the "caches" list.
+    for l in range(1, l):
+        a_prev = a
+
+        # use relu or leaky relu in hiden layers
+        a, cache = linear_activation_forward(
+            a_prev, parameters['W' + str(l)], parameters['b' + str(l)],
+            activation="leaky_relu")  # was relu
+        caches.append(cache)
+
+    # Implement LINEAR -> SIGMOID. Add "cache" to the "caches" list.
+
+    # output layer with sigmoid activation
+    al, cache = linear_activation_forward(
+        a, parameters['W' + str(l)], parameters['b' + str(l)], activation="sigmoid")
+
+    caches.append(cache)
+
+    # assert (aL.shape == (10, x.shape[1]))  # shape[0] should be same with shape[0] of output layer
+
+    return al, caches
+
+
+def l_model_backward_with_l2(al, y, caches, lambd):
+    """
+    Backward propagation for deep learning with L2 regularization.
+
+    @param al: output AL, numpy arrays
+    @param y: actual answers y, numpy arrays
+    @param caches: caches from forward propagation, dictionaries
+    @param lambd: regularization parameter lambda, floats
+    @return: gradients for gradient decent, dictionaries
+    """
+    grads = {}
+    l = len(caches)  # the number of layers
+    y = y.reshape(al.shape)  # after this line, Y is the same shape as AL
+
+    # Initializing the back propagation
+    dal = - (np.divide(y, al) - np.divide(1 - y, 1 - al))
+
+    # Lth layer Inputs: "AL, Y, caches". Outputs: "grads["dAL"], grads["dWL"], grads["dbL"]
+    current_cache = caches[l - 1]
+    grads["dA" + str(l - 1)], grads["dW" + str(l)], grads["db" + str(l)] = \
+        linear_activation_backward_with_l2(
+            dal, current_cache, lambd, activation="sigmoid")
+
+    for l in reversed(range(l - 1)):
+        # lth layer: (RELU -> LINEAR) gradients.
+        current_cache = caches[l]
+
+        # use relu or leaky relu for hidden layers
+        da_prev_temp, dw_temp, db_temp = \
+            linear_activation_backward_with_l2(
+                grads["dA" + str(l + 1)], current_cache, lambd, activation="leaky_relu")
+        grads["dA" + str(l)] = da_prev_temp
+        grads["dW" + str(l + 1)] = dw_temp
+        grads["db" + str(l + 1)] = db_temp
+
+    return grads
+
+
+def linear_activation_backward_with_l2(da, cache, lambd, activation):
+    """
+    activation step for backward propagation with multiple choices of activation function.
+
+    @param da: dA from last step of backward propagation, numpy arrays
+    @param cache: caches in deep learning, dictionaries
+    @param lambd: regularization parameter lambda, floats
+    @param activation: choice of activation, strings
+    @return: last dA, dW, db, numpy arrays
+    """
+
+    linear_cache, activation_cache = cache
+
+    # if activation == "relu":
+    # dZ = relu_backward(da, activation_cache)
+    # dA_prev, dW, db = linear_backward_with_l2(dZ, linear_cache, lambd)
+
+    if activation == "sigmoid":
+        dZ = sigmoid_backward(da, activation_cache)
+        dA_prev, dW, db = linear_backward_with_l2(dZ, linear_cache, lambd)
+
+    elif activation == "leaky_relu":
+        dZ = leaky_relu_backward(da, activation_cache)
+        dA_prev, dW, db = linear_backward_with_l2(dZ, linear_cache, lambd)
+
+    return dA_prev, dW, db
+
+
+def linear_activation_forward(a_prev, w, b, activation):
+    """
+    activation step for forward propagation with multiple choices of activation function.
+
+    @param a_prev: previous A from last step of forward propagation, numpy arrays
+    @param w: parameter W in current layer, numpy arrays
+    @param b: parameter b in current layer, numpy arrays
+    @param activation: choice of activation, strings
+    @return: current A and cache for following calculation
+    """
+
+    if activation == "sigmoid":
+        # Inputs: "A_prev, W, b". Outputs: "A, activation_cache".
+        z, linear_cache = linear_forward(a_prev, w, b)
+        a, activation_cache = sigmoid(z)
+
+    # elif activation == "relu":
+        # Inputs: "A_prev, W, b". Outputs: "A, activation_cache".
+    # z, linear_cache = linear_forward(a_prev, w, b)
+    # a, activation_cache = relu(z)
+
+    elif activation == "leaky_relu":
+        # Inputs: "A_prev, W, b". Outputs: "A, activation_cache".
+        z, linear_cache = linear_forward(a_prev, w, b)
+        a, activation_cache = leaky_relu(z)
+
+    assert (a.shape == (w.shape[0], a_prev.shape[1]))
+    cache = (linear_cache, activation_cache)
+    return a, cache
+
+
+def linear_backward_with_l2(dz, cache, lambd):
+    """
+    linear step in backward propagation.
+
+    @param dz: current dZ, numpy arrays
+    @param cache: caches from previous calculation, dictionaries
+    @param lambd: regularization parameter lambda, floats
+    @return: previous dA, current dW, db, numpy arrays
+    """
+
+    a_prev, w, b = cache
+    m = a_prev.shape[1]
+    dW = 1. / m * np.dot(dz, a_prev.T) + (lambd / m) * w
+    db = 1. / m * np.sum(dz, axis=1, keepdims=True)
+    dA_prev = np.dot(w.T, dz)
+
+    # dA_prev = dropouts_backward(dA_prev, D, keep_prob)
+
+    assert (dA_prev.shape == a_prev.shape)
+    assert (dW.shape == w.shape)
+    assert (db.shape == b.shape)
+
+    return dA_prev, dW, db
+
+
+def linear_forward(a, w, b):
+    """
+    linear step for forward propagation
+    @param a: current A, numpy arrays
+    @param w: current parameter W, numpy arrays
+    @param b: current parameter b, numpy arrays
+    @return: current z, and caches for following calculations, numpy arrays and dictionaries
+    """
+
+    z = w.dot(a) + b
+
+    assert (z.shape == (w.shape[0], a.shape[1]))
+    cache = (a, w, b)
+
+    return z, cache
+
+
+def one_vs_all_prediction(prob_matrix):
+    """
+    Compare every probability, get the maximum and output the index.
+
+    @param prob_matrix: probability matrix, numpy arrays
+    @return: prediction generated from probability matrix, numpy arrays
+    """
+    m = prob_matrix.shape[1]
+
+    prediction = np.argmax(prob_matrix, axis=0)
+    prediction = np.array([prediction])  # keep dimensions
+
+    assert (prediction.shape == (1, m))
+
+    return prediction
+
+
+def relu(z):
+    """
+    relu function
+
+    @param z: input A, numpy arrays or numbers
+    @return: output A, numpy arrays or numbers
+    """
+    if isinstance(z, np.float) or isinstance(z, np.int64) or isinstance(z, float) or isinstance(z, int):
+        z = np.array([[z]])
+
+    a = np.maximum(0, z)
+
+    assert (a.shape == z.shape)
+
+    cache = z
+    return a, cache
+
+
+def relu_backward(da, cache):
+    """
+    compute gradient of relu function.
+
+    @param da: input dA, numpy arrays or numbers
+    @param cache: caches with Z, dictionaries
+    @return: result dZ, numpy arrays or numbers
+    """
+
+    z = cache
+    dz = np.array(da, copy=True)  # just converting dz to a correct object.
+
+    # When z <= 0s you should set dz to 0 as well.
+    dz[z <= 0] = 0
+
+    assert (dz.shape == z.shape)
+
+    return dz
+
+
+def leaky_relu(z):
+    """
+    leaky relu function
+
+    @param z: input Z, numpy arrays or numbers
+    @return: result A and caches for following calculation
+    """
+
+    if isinstance(z, np.float) or isinstance(z, np.int64) or isinstance(z, float) or isinstance(z, int):
+        print('passed')
+        z = np.array([[z]])
+
+    a = np.maximum(0.01 * z, z)
+
+    assert (a.shape == z.shape)
+
+    cache = z
+    return a, cache
+
+
+def leaky_relu_backward(da, cache):
+    """
+    compute gradients of leaky relu function.
+
+    @param da: input dA, numpy arrays or numbers
+    @param cache: cache with Z, dictionaries
+    @return: result dZ, numpy arrays or numbers
+    """
+    z = cache
+    dz = np.array(da, copy=True)  # just converting dz to a correct object.
+
+    # When z < 0, you should set dz to 0.01  as well.
+    # temp = np.ones(Z.shape)
+    # temp[Z <= 0] = 0.01
+    # dZ = dZ*temp
+    # Z[Z > 0] = 1
+    # Z[Z != 1] = 0.01
+    # dZ = dZ*Z
+
+    temp = np.ones_like(z)
+    print('temp1: ' + str(temp))
+    temp[z <= 0] = 0.01
+    print('temp2: ' + str(temp))
+    dz = dz*temp
+
+    assert (dz.shape == z.shape)
+
+    return dz
+
+
+def sigmoid(z):
+    """
+    sigmoid function.
+
+    @param z: input Z, numpy arrays or numbers
+    @return: result A, caches for following calculations, numpy arrays or numbers, dictionaries
+    """
+
+    a = 1 / (1 + np.exp(-z))
+    cache = z
+
+    return a, cache
+
+
+def sigmoid_backward(da, cache):
+    """
+    compute gradients of sigmoid function.
+
+    @param da: input dA, numpy arrays or numbers
+    @param cache: caches with Z, dictionaries
+    @return: result dZ, numpy arrays or numbers
+    """
+    if isinstance(da, np.float) or isinstance(da, np.int64) or isinstance(da, float) or isinstance(da, int):
+        da = np.array([[da]])
+
+    if isinstance(cache, np.float) or isinstance(cache, np.int64) or isinstance(cache, float) or isinstance(cache, int):
+        cache = np.array([[cache]])
+
+    z = cache
+
+    s = 1 / (1 + np.exp(-z))
+    dz = da * s * (1 - s)
+
+    assert (dz.shape == z.shape)
+
+    return dz
+
+
+"""
+unused dropout functions
+def dropouts_forward(A,  activation_cache, keep_prob):
+    D = np.random.rand(A.shape[0], A.shape[1])
+    D = D < keep_prob
+    A = A * D
+    A = A / keep_prob
+    cache = (activation_cache, D)
+    return A, cache
+
+
+def dropouts_backward(dA, D, keep_prob):
+    dA = dA*D
+    dA = dA/keep_prob
+    return dA
+"""
+
+"""
+def update_parameters(parameters, grads, learning_rate):
+#add """"""
+    update parameters with gradients.
+
+    @param parameters: input parameters, dictionaries
+    @param grads: gradients, dictionaries
+    @param learning_rate: hyper-parameter alpha for deep learning, floats
+    @return: updated parameters, dictionaries
+
+    L = len(parameters) // 2  # number of layers in the neural network
+
+    # Update rule for each parameter. Use a for loop.
+    for l in range(L):
+        parameters["W" + str(l + 1)] = parameters["W" + str(l + 1)] - learning_rate * grads["dW" + str(l + 1)]
+        parameters["b" + str(l + 1)] = parameters["b" + str(l + 1)] - learning_rate * grads["db" + str(l + 1)]
+
+    return parameters
+"""

--- a/ml/common/parameters.py
+++ b/ml/common/parameters.py
@@ -37,3 +37,44 @@ class Parameters:
         """
         LOGGER.info('saving parameters: {} ...'.format(self._param_file))
         np.save(self._param_file, parameters, allow_pickle=True, fix_imports=True)
+
+    def update(self, grads, learning_rate):
+        """
+        update parameters with gradients.
+
+        @param grads: gradients, dictionaries
+        @param learning_rate: hyper-parameter alpha for deep learning, floats
+        """
+
+        L = len(self._parameters) // 2  # number of layers in the neural network
+
+        # Update rule for each parameter. Use a for loop.
+        for l in range(L):
+            self._parameters["W" + str(l + 1)] = \
+                self._parameters["W" + str(l + 1)] - learning_rate * grads["dW" + str(l + 1)]
+            self._parameters["b" + str(l + 1)] = \
+                self._parameters["b" + str(l + 1)] - learning_rate * grads["db" + str(l + 1)]
+
+    def initialize_parameters_deep_he(self, layer_dims):
+        """
+        initialization for deep learning with HE random algorithm to prevent fading & exploding gradients.
+
+        @param layer_dims: dimensions of layers, lists
+        @return: initialized parameters
+        """
+
+        np.random.seed(1)
+        parameters = {}
+        l = len(layer_dims)  # number of layers in the network
+
+        for l in range(1, l):
+            # initialized W with random and HE term
+            parameters['W' + str(l)] = np.random.randn(layer_dims[l], layer_dims[l - 1]) * np.sqrt(
+                2 / layer_dims[l - 1])
+
+            parameters['b' + str(l)] = np.zeros((layer_dims[l], 1))
+
+            assert (parameters['W' + str(l)].shape == (layer_dims[l], layer_dims[l - 1]))
+            assert (parameters['b' + str(l)].shape == (layer_dims[l], 1))
+
+        self._parameters = parameters

--- a/ml/misc/interview.py
+++ b/ml/misc/interview.py
@@ -1,0 +1,28 @@
+"""
+interview.py functions that are for interview practice
+"""
+
+
+def get_2nd_largest(num_list):
+    """
+    Get the second largest number in a list of numbers
+    :param num_list: list of numbers, list
+    :return:
+    """
+    if not isinstance(num_list, list):
+        return None
+    m1st = None
+    m2nd = None
+    counter = 0
+    for item in num_list:
+        if not isinstance(item, (int, float)):
+            continue
+        if m2nd is None or item > m2nd:
+            m2nd = item
+        if m1st is None or item > m1st:
+            m2nd = m1st
+            m1st = item
+        counter += 1
+    if counter < 2:
+        return None
+    return m2nd

--- a/tests/test_common_mathEx.py
+++ b/tests/test_common_mathEx.py
@@ -11,15 +11,15 @@ from ml.common.mathEx import \
     change_to_multi_class, \
     compute_cost, \
     compute_cost_with_l2_regularization, \
-    relu, \
-    relu_backward, \
     leaky_relu, \
     leaky_relu_backward, \
-    sigmoid, \
-    sigmoid_backward, \
     l_model_forward, \
     l_model_backward_with_l2, \
-    one_vs_all_prediction
+    one_vs_all_prediction, \
+    relu, \
+    relu_backward, \
+    sigmoid, \
+    sigmoid_backward
 from ml.utils.logger import get_logger
 
 LOGGER = get_logger(__name__)
@@ -77,24 +77,23 @@ class MathExTests(unittest.TestCase):
             "al": [[0.01, 0.1, 0.2, 0.3], [0.1, 0.2, 0.3, 0.4]],
             "y": [[0.2, 0.3, 0.4, 0.5], [0.3, 0.4, 0.5, 0.6]],
             "result": [[3.2688439245595067]],
-        },
-            {
-                "al": None,
-                "y": None,
-                "result": [[0.6931471805599453]],
-            }]
+        }, {
+            "al": None,
+            "y": None,
+            "result": [[0.6931471805599453]],
+        }]
 
         for test in tests:
             al = test["al"]
             y = test["y"]
             expected = test['result']
             result = compute_cost(numpy.array(al), numpy.array(y))
-            self.assertListEqual([[result]], expected)
+            self.assertTrue(numpy.abs(expected - result) <= 0.000001)
         al = 0.5
         y = 0.6
         expected = [[0.6931471805599453]]
         result = compute_cost(al, y)
-        self.assertListEqual([[result]], expected)
+        self.assertTrue(numpy.abs(expected - result) <= 0.000001)
 
     def test_compute_cost_with_l2_regularization(self):
         """
@@ -136,7 +135,7 @@ class MathExTests(unittest.TestCase):
         lambd = 0.075
         expected = [[0.8806471805599453]]
         result = compute_cost_with_l2_regularization(al, y, parameters, lambd)
-        self.assertListEqual([[result]], expected)
+        self.assertTrue(numpy.abs(expected - result) <= 0.000001)
 
         with self.assertRaises(KeyError):
             compute_cost_with_l2_regularization(al, y, broken_parameters, lambd)
@@ -146,10 +145,15 @@ class MathExTests(unittest.TestCase):
         test ml.common.mathEx.relu
         :return:
         """
-        tests = [
-            {"z": [[1], [-1], [2], [-2]], "result_a": [[1], [0], [2], [0]], "result_cache": [[1], [-1], [2], [-2]]},
-            {"z": [[-1]], "result_a": [[0]], "result_cache": [[-1]]},
-        ]
+        tests = [{
+            "z": [[1], [-1], [2], [-2]],
+            "result_a": [[1], [0], [2], [0]],
+            "result_cache": [[1], [-1], [2], [-2]],
+        }, {
+            "z": [[-1]],
+            "result_a": [[0]],
+            "result_cache": [[-1]],
+        }]
         for test in tests:
             z = test["z"]
             expected_a = test["result_a"]
@@ -158,10 +162,15 @@ class MathExTests(unittest.TestCase):
             self.assertListEqual(a.tolist(), expected_a)
             self.assertListEqual(cache.tolist(), expected_cache)
 
-        tests_ints = [
-            {"z": 1, "result_a": [[1]], "result_cache": [[1]]},
-            {"z": -1, "result_a": [[0]], "result_cache": [[-1]]}
-        ]
+        tests_ints = [{
+            "z": 1,
+            "result_a": [[1]],
+            "result_cache": [[1]],
+        }, {
+            "z": -1,
+            "result_a": [[0]],
+            "result_cache": [[-1]],
+        }]
         for test in tests_ints:
             z = test["z"]
             expected_a = test["result_a"]
@@ -175,11 +184,19 @@ class MathExTests(unittest.TestCase):
         test ml.common.mathEx.relu_backward
         :return:
         """
-        tests = [
-            {"da": [[1], [2], [3], [4]], "cache": [[1], [0], [1], [0]], "result": [[1], [0], [3], [0]]},
-            {"da": [[1]], "cache": [[-1]], "result": [[0]]},
-            {"da": [[1]], "cache": [[0]], "result": [[0]]}
-        ]
+        tests = [{
+            "da": [[1], [2], [3], [4]],
+            "cache": [[1], [0], [1], [0]],
+            "result": [[1], [0], [3], [0]],
+        }, {
+            "da": [[1]],
+            "cache": [[-1]],
+            "result": [[0]],
+        }, {
+            "da": [[1]],
+            "cache": [[0]],
+            "result": [[0]],
+        }]
         for test in tests:
             da = test["da"]
             cache = test["cache"]
@@ -192,12 +209,23 @@ class MathExTests(unittest.TestCase):
         test ml.common.mathEx.leaky_relu
         :return:
         """
-        tests = [
-            {"z": [[-1], [0], [1], [2]], "a": [[-0.01], [0], [1], [2]], "cache": [[-1], [0], [1], [2]]},
-            {"z": [[-1, 0, 1, 2]], "a": [[-0.01, 0, 1, 2]], "cache": [[-1, 0, 1, 2]]},
-            {"z": [[-2]], "a": [[-0.02]], "cache": [[-2]]},
-            {"z": [[2]], "a": [[2]], "cache": [[2]]}
-        ]
+        tests = [{
+            "z": [[-1], [0], [1], [2]],
+            "a": [[-0.01], [0], [1], [2]],
+            "cache": [[-1], [0], [1], [2]],
+        }, {
+            "z": [[-1, 0, 1, 2]],
+            "a": [[-0.01, 0, 1, 2]],
+            "cache": [[-1, 0, 1, 2]],
+        }, {
+            "z": [[-2]],
+            "a": [[-0.02]],
+            "cache": [[-2]],
+        }, {
+            "z": [[2]],
+            "a": [[2]],
+            "cache": [[2]],
+        }]
         for test in tests:
             z = test["z"]
             expected_a = test["a"]
@@ -218,11 +246,19 @@ class MathExTests(unittest.TestCase):
         test ml.common.mathEx.leaky_relu_backward
         :return:
         """
-        tests = [
-            {"da": [[1], [2], [3], [4]], "cache": [[1], [-1], [1], [0]], "result": [[1], [0], [3], [0]]},
-            {"da": [[1]], "cache": [[-1]], "result": [[0]]},
-            {"da": [[1]], "cache": [[0]], "result": [[0]]}
-        ]
+        tests = [{
+            "da": [[1], [2], [3], [4]],
+            "cache": [[1], [-1], [1], [0]],
+            "result": [[1], [0], [3], [0]],
+        }, {
+            "da": [[1]],
+            "cache": [[-1]],
+            "result": [[0]],
+        }, {
+            "da": [[1]],
+            "cache": [[0]],
+            "result": [[0]],
+        }]
         for test in tests:
             da = test["da"]
             cache = test["cache"]
@@ -235,12 +271,23 @@ class MathExTests(unittest.TestCase):
         test ml.common.mathEx.sigmoid
         :return:
         """
-        tests_array = [
-            {"z": [[0]], "a": [[0.5]], "cache": [[0]]},
-            {"z": [[0.01]], "a": [[0.5024999791668749]], "cache": [[0.01]]},
-            {"z": [[0.5], [0.6]], "a": [[0.6224593312018546], [0.6456563062257954]], "cache": [[0.5], [0.6]]},
-            {"z": [[0.5, 0.6]], "a": [[0.6224593312018546, 0.6456563062257954]], "cache": [[0.5, 0.6]]}
-        ]
+        tests_array = [{
+            "z": [[0]],
+            "a": [[0.5]],
+            "cache": [[0]],
+        }, {
+            "z": [[0.01]],
+            "a": [[0.5024999791668749]],
+            "cache": [[0.01]],
+        }, {
+            "z": [[0.5], [0.6]],
+            "a": [[0.6224593312018546], [0.6456563062257954]],
+            "cache": [[0.5], [0.6]],
+        }, {
+            "z": [[0.5, 0.6]],
+            "a": [[0.6224593312018546, 0.6456563062257954]],
+            "cache": [[0.5, 0.6]],
+        }]
 
         for test in tests_array:
             z = test["z"]
@@ -250,10 +297,15 @@ class MathExTests(unittest.TestCase):
             self.assertListEqual(a.tolist(), expected_a)
             self.assertListEqual(cache.tolist(), expected_cache)
 
-        tests_int = [
-            {"z": 0, "a": 0.5, "cache": 0},
-            {"z": 0.01, "a": 0.5024999791668749, "cache": 0.01}
-        ]
+        tests_int = [{
+            "z": 0,
+            "a": 0.5,
+            "cache": 0,
+        }, {
+            "z": 0.01,
+            "a": 0.5024999791668749,
+            "cache": 0.01,
+        }]
 
         for test in tests_int:
             z = test["z"]
@@ -268,11 +320,19 @@ class MathExTests(unittest.TestCase):
         test ml.common.mathEx.sigmoid_backward
         :return:
         """
-        tests_array = [
-            {"da": [[0.5]], "cache": [[0]], "result": [[0.125]]},
-            {"da": [[-0.5, 0.75]], "cache": [[0, 0.5]], "result": [[-0.125,  0.17625278415119588]]},
-            {"da": [[-0.5], [0.75]], "cache": [[0], [0.5]], "result": [[-0.125], [0.17625278415119588]]}
-        ]
+        tests_array = [{
+            "da": [[0.5]],
+            "cache": [[0]],
+            "result": [[0.125]],
+        }, {
+            "da": [[-0.5, 0.75]],
+            "cache": [[0, 0.5]],
+            "result": [[-0.125,  0.17625278415119588]],
+        }, {
+            "da": [[-0.5], [0.75]],
+            "cache": [[0], [0.5]],
+            "result": [[-0.125], [0.17625278415119588]],
+        }]
 
         for test in tests_array:
             da = test["da"]
@@ -281,11 +341,19 @@ class MathExTests(unittest.TestCase):
             result = sigmoid_backward(numpy.array(da), numpy.array(cache))
             self.assertListEqual(result.tolist(), expected)
 
-        tests_number = [
-            {"da": 0.5, "cache": 0, "result": [[0.125]]},
-            {"da": -0.5, "cache": 0, "result": [[-0.125]]},
-            {"da": 0.75, "cache": 0.5, "result": [[0.17625278415119588]]}
-        ]
+        tests_number = [{
+            "da": 0.5,
+            "cache": 0,
+            "result": [[0.125]],
+        }, {
+            "da": -0.5,
+            "cache": 0,
+            "result": [[-0.125]],
+        }, {
+            "da": 0.75,
+            "cache": 0.5,
+            "result": [[0.17625278415119588]],
+        }]
 
         for test in tests_number:
             da = test["da"]
@@ -299,22 +367,25 @@ class MathExTests(unittest.TestCase):
         test ml.common.l_model_forward
         :return:
         """
-        tests = [
-            {"x": numpy.array([[1, 2], [3, 4]]),
-             "parameters": {"W1": numpy.array([[0, 0], [0, 0]]),
-                            "b1": numpy.array([[0], [0]]),
-                            "W2": numpy.array([[0, 0], [0, 0]]),
-                            "b2": numpy.array([[0], [0]])},
-             "al": numpy.array([[0.5, 0.5], [0.5, 0.5]]),
-             "caches": [((numpy.array([[1, 2], [3, 4]]),
-                          numpy.array([[0, 0], [0, 0]]),
-                          numpy.array([[0], [0]])),
-                         numpy.array([[0, 0], [0, 0]])),
-                        ((numpy.array([[0., 0.], [0., 0.]]),
-                          numpy.array([[0, 0], [0, 0]]),
-                          numpy.array([[0], [0]])),
-                         numpy.array([[0., 0.], [0., 0.]]))]}
-        ]
+        tests = [{
+            "x": numpy.array([[1, 2], [3, 4]]),
+            "parameters": {
+                "W1": numpy.array([[0, 0], [0, 0]]),
+                "b1": numpy.array([[0], [0]]),
+                "W2": numpy.array([[0, 0], [0, 0]]),
+                "b2": numpy.array([[0], [0]])},
+            "al": numpy.array([[0.5, 0.5], [0.5, 0.5]]),
+            "caches": [
+                (
+                    (numpy.array([[1, 2], [3, 4]]),
+                     numpy.array([[0, 0], [0, 0]]),
+                     numpy.array([[0], [0]])),
+                    numpy.array([[0, 0], [0, 0]]),
+                 ), ((numpy.array([[0., 0.], [0., 0.]]),
+                      numpy.array([[0, 0], [0, 0]]),
+                      numpy.array([[0], [0]])),
+                     numpy.array([[0., 0.], [0., 0.]]))],
+        }]
         for test in tests:
             x = test["x"]
             parameters = test["parameters"]
@@ -327,27 +398,25 @@ class MathExTests(unittest.TestCase):
         test ml.common.mathEx.l_model_backward_with_l2
         :return:
         """
-        tests = [
-            {
-                "al": numpy.array([[0.5, 0.5], [0.5, 0.5]]),
-                "y": numpy.array([[0, 0], [0, 0]]),
-                "caches": [((numpy.array([[1, 2], [3, 4]]),
-                             numpy.array([[0, 0], [0, 0]]),
-                             numpy.array([[0], [0]])),
-                            numpy.array([[0, 0], [0, 0]])),
-                           ((numpy.array([[0., 0.], [0., 0.]]),
-                             numpy.array([[0, 0], [0, 0]]),
-                             numpy.array([[0], [0]])),
-                            numpy.array([[0., 0.], [0., 0.]]))],
-                "lambd": 0.075,
-                "result": {"dA1": numpy.array([[0., 0.], [0., 0.]]),
-                           "dW2": numpy.array([[0., 0.], [0., 0.]]),
-                           "db2": numpy.array([[0.5], [0.5]]),
-                           "dA0": numpy.array([[0., 0.], [0., 0.]]),
-                           "dW1": numpy.array([[0., 0.], [0., 0.]]),
-                           "db1": numpy.array([[0.], [0.]])},
-            }
-        ]
+        tests = [{
+            "al": numpy.array([[0.5, 0.5], [0.5, 0.5]]),
+            "y": numpy.array([[0, 0], [0, 0]]),
+            "caches": [((numpy.array([[1, 2], [3, 4]]),
+                         numpy.array([[0, 0], [0, 0]]),
+                         numpy.array([[0], [0]])),
+                        numpy.array([[0, 0], [0, 0]])),
+                       ((numpy.array([[0., 0.], [0., 0.]]),
+                         numpy.array([[0, 0], [0, 0]]),
+                         numpy.array([[0], [0]])),
+                        numpy.array([[0., 0.], [0., 0.]]))],
+            "lambd": 0.075,
+            "result": {"dA1": numpy.array([[0., 0.], [0., 0.]]),
+                       "dW2": numpy.array([[0., 0.], [0., 0.]]),
+                       "db2": numpy.array([[0.5], [0.5]]),
+                       "dA0": numpy.array([[0., 0.], [0., 0.]]),
+                       "dW1": numpy.array([[0., 0.], [0., 0.]]),
+                       "db1": numpy.array([[0.], [0.]])},
+        }]
         for test in tests:
             al = test["al"]
             y = test["y"]
@@ -369,16 +438,13 @@ class MathExTests(unittest.TestCase):
         test ml.common.mathEx.one_vs_all_prediction
         :return:
         """
-        tests = [
-            {
-                "pm": [[0], [0.1], [0.2]],
-                "result": [[2]],
-            },
-            {
-                "pm": [[0, 1, 2], [0.1, 0.2, 0.3], [0.3, 0.2, 0.1]],
-                "result": [[2, 0, 0]],
-            }
-        ]
+        tests = [{
+            "pm": [[0], [0.1], [0.2]],
+            "result": [[2]],
+            }, {
+            "pm": [[0, 1, 2], [0.1, 0.2, 0.3], [0.3, 0.2, 0.1]],
+            "result": [[2, 0, 0]],
+        }]
         for test in tests:
             prob_matrix = test["pm"]
             expected = test["result"]

--- a/tests/test_common_mathEx.py
+++ b/tests/test_common_mathEx.py
@@ -1,0 +1,386 @@
+"""
+# test_classifier_datasvc.py.py
+
+"""
+import logging
+import os
+import unittest
+import numpy
+
+from ml.common.mathEx import \
+    change_to_multi_class, \
+    compute_cost, \
+    compute_cost_with_l2_regularization, \
+    relu, \
+    relu_backward, \
+    leaky_relu, \
+    leaky_relu_backward, \
+    sigmoid, \
+    sigmoid_backward, \
+    l_model_forward, \
+    l_model_backward_with_l2, \
+    one_vs_all_prediction
+from ml.utils.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+class MathExTests(unittest.TestCase):
+    """
+    mathExTests includes all unit tests for ml.common.mathEx module
+    """
+    @classmethod
+    def teardown_class(cls):
+        logging.shutdown()
+
+    def setUp(self):
+        """setup for test"""
+        self.test_path = os.path.dirname(os.path.realpath(__file__))
+        self.repo_path = os.path.dirname(self.test_path)
+        self.proj_path = os.path.join(self.repo_path, "ml")
+        self.base_path = os.path.join(self.repo_path, "ml", "common")
+        self.data_path = os.path.join(self.repo_path, "ml", "common", "datasets")
+        pass
+
+    def tearDown(self):
+        """tearing down at the end of the test"""
+        pass
+
+    def test_change_to_multi_class(self):
+        """
+        test ml.common.mathEx.change_to_multi_class
+        :return:
+        """
+        tests = [
+            {"y": [[0, 1, 2]], "result": [[1, 0, 0], [0, 1, 0], [0, 0, 1]]},
+            {"y": [[0, 3]], "result": [[1, 0], [0, 0], [0, 0], [0, 1]]},
+            {"y": [[0]], "result": [[1]]},
+            {"y": [[0.5]], "result": [[1]]},
+            {"y": None, "result": [[1]]},
+        ]
+
+        for test in tests:
+            y = test["y"]
+            expected = test['result']
+            result = change_to_multi_class(numpy.array(y))
+            self.assertListEqual(result.tolist(), expected)
+
+    def test_compute_cost(self):
+        """
+        test ml.common.mathEx.compute_cost
+        :return:
+        """
+        tests = [{
+            "al": [[0.5]], "y": [[0.6]],
+            "result": [[0.6931471805599453]],
+        }, {
+            "al": [[0.01, 0.1, 0.2, 0.3], [0.1, 0.2, 0.3, 0.4]],
+            "y": [[0.2, 0.3, 0.4, 0.5], [0.3, 0.4, 0.5, 0.6]],
+            "result": [[3.2688439245595067]],
+        },
+            {
+                "al": None,
+                "y": None,
+                "result": [[0.6931471805599453]],
+            }]
+
+        for test in tests:
+            al = test["al"]
+            y = test["y"]
+            expected = test['result']
+            result = compute_cost(numpy.array(al), numpy.array(y))
+            self.assertListEqual([[result]], expected)
+        al = 0.5
+        y = 0.6
+        expected = [[0.6931471805599453]]
+        result = compute_cost(al, y)
+        self.assertListEqual([[result]], expected)
+
+    def test_compute_cost_with_l2_regularization(self):
+        """
+        test ml.common.mathEx.compute_cost_with_l2_regularization
+        :return:
+        """
+        tests = [{
+            "al": [[0.01, 0.1, 0.2, 0.3], [0.1, 0.2, 0.3, 0.4]],
+            "y": [[0.2, 0.3, 0.4, 0.5], [0.3, 0.4, 0.5, 0.6]],
+            "parameters": {"W1": 1, "W2": 2, "W3": 3, "W4": 4},
+            "lambd": 0.075,
+            "result": 3.3157189245595067,
+        }, {
+            "al": [[0.5]],
+            "y": [[0.6]],
+            "parameters": {"W1": 1, "W2": 2, "W3": 3, "W4": 4},
+            "lambd": 0.075,
+            "result": 0.8806471805599453,
+        }, {
+            "al": None,
+            "y": None,
+            "parameters": {"W1": 1, "W2": 2, "W3": 3, "W4": 4},
+            "lambd": 0.075,
+            "result": 0.8806471805599453,
+        }]
+
+        for test in tests:
+            al = test["al"]
+            y = test["y"]
+            parameters = test["parameters"]
+            lambd = test["lambd"]
+            expected = test["result"]
+            result = compute_cost_with_l2_regularization(numpy.array(al), numpy.array(y), parameters, lambd)
+            self.assertTrue(numpy.abs(expected - result) <= 0.000001)
+        al = 0.5
+        y = 0.6
+        parameters = {"W1": 1, "W2": 2, "W3": 3, "W4": 4}
+        broken_parameters = {"S1": 1, "b1": 0}
+        lambd = 0.075
+        expected = [[0.8806471805599453]]
+        result = compute_cost_with_l2_regularization(al, y, parameters, lambd)
+        self.assertListEqual([[result]], expected)
+
+        with self.assertRaises(KeyError):
+            compute_cost_with_l2_regularization(al, y, broken_parameters, lambd)
+
+    def test_relu(self):
+        """
+        test ml.common.mathEx.relu
+        :return:
+        """
+        tests = [
+            {"z": [[1], [-1], [2], [-2]], "result_a": [[1], [0], [2], [0]], "result_cache": [[1], [-1], [2], [-2]]},
+            {"z": [[-1]], "result_a": [[0]], "result_cache": [[-1]]},
+        ]
+        for test in tests:
+            z = test["z"]
+            expected_a = test["result_a"]
+            expected_cache = test["result_cache"]
+            a, cache = relu(numpy.array(z))
+            self.assertListEqual(a.tolist(), expected_a)
+            self.assertListEqual(cache.tolist(), expected_cache)
+
+        tests_ints = [
+            {"z": 1, "result_a": [[1]], "result_cache": [[1]]},
+            {"z": -1, "result_a": [[0]], "result_cache": [[-1]]}
+        ]
+        for test in tests_ints:
+            z = test["z"]
+            expected_a = test["result_a"]
+            expected_cache = test["result_cache"]
+            a, cache = relu(z)
+            self.assertListEqual(a.tolist(), expected_a)
+            self.assertListEqual(cache.tolist(), expected_cache)
+
+    def test_relu_backward(self):
+        """
+        test ml.common.mathEx.relu_backward
+        :return:
+        """
+        tests = [
+            {"da": [[1], [2], [3], [4]], "cache": [[1], [0], [1], [0]], "result": [[1], [0], [3], [0]]},
+            {"da": [[1]], "cache": [[-1]], "result": [[0]]},
+            {"da": [[1]], "cache": [[0]], "result": [[0]]}
+        ]
+        for test in tests:
+            da = test["da"]
+            cache = test["cache"]
+            expected = test["result"]
+            test = relu_backward(numpy.array(da), numpy.array(cache))
+            self.assertListEqual(test.tolist(), expected)
+
+    def test_leaky_relu(self):
+        """
+        test ml.common.mathEx.leaky_relu
+        :return:
+        """
+        tests = [
+            {"z": [[-1], [0], [1], [2]], "a": [[-0.01], [0], [1], [2]], "cache": [[-1], [0], [1], [2]]},
+            {"z": [[-1, 0, 1, 2]], "a": [[-0.01, 0, 1, 2]], "cache": [[-1, 0, 1, 2]]},
+            {"z": [[-2]], "a": [[-0.02]], "cache": [[-2]]},
+            {"z": [[2]], "a": [[2]], "cache": [[2]]}
+        ]
+        for test in tests:
+            z = test["z"]
+            expected_a = test["a"]
+            expected_cache = test["cache"]
+            a, cache = leaky_relu(numpy.array(z))
+            self.assertListEqual(a.tolist(), expected_a)
+            self.assertListEqual(cache.tolist(), expected_cache)
+
+        z = -1
+        expected_a = [[-0.01]]
+        expected_cache = [[-1]]
+        a, cache = leaky_relu(z)
+        self.assertListEqual(a.tolist(), expected_a)
+        self.assertListEqual(cache.tolist(), expected_cache)
+
+    def test_leaky_relu_backward(self):
+        """
+        test ml.common.mathEx.leaky_relu_backward
+        :return:
+        """
+        tests = [
+            {"da": [[1], [2], [3], [4]], "cache": [[1], [-1], [1], [0]], "result": [[1], [0], [3], [0]]},
+            {"da": [[1]], "cache": [[-1]], "result": [[0]]},
+            {"da": [[1]], "cache": [[0]], "result": [[0]]}
+        ]
+        for test in tests:
+            da = test["da"]
+            cache = test["cache"]
+            expected = test["result"]
+            test = leaky_relu_backward(numpy.array(da), numpy.array(cache))
+            self.assertListEqual(test.tolist(), expected)
+
+    def test_sigmoid(self):
+        """
+        test ml.common.mathEx.sigmoid
+        :return:
+        """
+        tests_array = [
+            {"z": [[0]], "a": [[0.5]], "cache": [[0]]},
+            {"z": [[0.01]], "a": [[0.5024999791668749]], "cache": [[0.01]]},
+            {"z": [[0.5], [0.6]], "a": [[0.6224593312018546], [0.6456563062257954]], "cache": [[0.5], [0.6]]},
+            {"z": [[0.5, 0.6]], "a": [[0.6224593312018546, 0.6456563062257954]], "cache": [[0.5, 0.6]]}
+        ]
+
+        for test in tests_array:
+            z = test["z"]
+            expected_a = test["a"]
+            expected_cache = test["cache"]
+            a, cache = sigmoid(numpy.array(z))
+            self.assertListEqual(a.tolist(), expected_a)
+            self.assertListEqual(cache.tolist(), expected_cache)
+
+        tests_int = [
+            {"z": 0, "a": 0.5, "cache": 0},
+            {"z": 0.01, "a": 0.5024999791668749, "cache": 0.01}
+        ]
+
+        for test in tests_int:
+            z = test["z"]
+            expected_a = test["a"]
+            expected_cache = test["cache"]
+            a, cache = sigmoid(z)
+            self.assertEqual(a, expected_a)
+            self.assertEqual(cache, expected_cache)
+
+    def test_sigmoid_backward(self):
+        """
+        test ml.common.mathEx.sigmoid_backward
+        :return:
+        """
+        tests_array = [
+            {"da": [[0.5]], "cache": [[0]], "result": [[0.125]]},
+            {"da": [[-0.5, 0.75]], "cache": [[0, 0.5]], "result": [[-0.125,  0.17625278415119588]]},
+            {"da": [[-0.5], [0.75]], "cache": [[0], [0.5]], "result": [[-0.125], [0.17625278415119588]]}
+        ]
+
+        for test in tests_array:
+            da = test["da"]
+            cache = test["cache"]
+            expected = test["result"]
+            result = sigmoid_backward(numpy.array(da), numpy.array(cache))
+            self.assertListEqual(result.tolist(), expected)
+
+        tests_number = [
+            {"da": 0.5, "cache": 0, "result": [[0.125]]},
+            {"da": -0.5, "cache": 0, "result": [[-0.125]]},
+            {"da": 0.75, "cache": 0.5, "result": [[0.17625278415119588]]}
+        ]
+
+        for test in tests_number:
+            da = test["da"]
+            cache = test["cache"]
+            expected = test["result"]
+            result = sigmoid_backward(da, cache)
+            self.assertListEqual(result.tolist(), expected)
+
+    def test_l_model_forward(self):
+        """
+        test ml.common.l_model_forward
+        :return:
+        """
+        tests = [
+            {"x": numpy.array([[1, 2], [3, 4]]),
+             "parameters": {"W1": numpy.array([[0, 0], [0, 0]]),
+                            "b1": numpy.array([[0], [0]]),
+                            "W2": numpy.array([[0, 0], [0, 0]]),
+                            "b2": numpy.array([[0], [0]])},
+             "al": numpy.array([[0.5, 0.5], [0.5, 0.5]]),
+             "caches": [((numpy.array([[1, 2], [3, 4]]),
+                          numpy.array([[0, 0], [0, 0]]),
+                          numpy.array([[0], [0]])),
+                         numpy.array([[0, 0], [0, 0]])),
+                        ((numpy.array([[0., 0.], [0., 0.]]),
+                          numpy.array([[0, 0], [0, 0]]),
+                          numpy.array([[0], [0]])),
+                         numpy.array([[0., 0.], [0., 0.]]))]}
+        ]
+        for test in tests:
+            x = test["x"]
+            parameters = test["parameters"]
+            expected_al = test["al"]
+            al, caches = l_model_forward(x, parameters)
+            self.assertListEqual(al.tolist(), expected_al.tolist())
+
+    def test_l_model_backward_with_l2(self):
+        """
+        test ml.common.mathEx.l_model_backward_with_l2
+        :return:
+        """
+        tests = [
+            {
+                "al": numpy.array([[0.5, 0.5], [0.5, 0.5]]),
+                "y": numpy.array([[0, 0], [0, 0]]),
+                "caches": [((numpy.array([[1, 2], [3, 4]]),
+                             numpy.array([[0, 0], [0, 0]]),
+                             numpy.array([[0], [0]])),
+                            numpy.array([[0, 0], [0, 0]])),
+                           ((numpy.array([[0., 0.], [0., 0.]]),
+                             numpy.array([[0, 0], [0, 0]]),
+                             numpy.array([[0], [0]])),
+                            numpy.array([[0., 0.], [0., 0.]]))],
+                "lambd": 0.075,
+                "result": {"dA1": numpy.array([[0., 0.], [0., 0.]]),
+                           "dW2": numpy.array([[0., 0.], [0., 0.]]),
+                           "db2": numpy.array([[0.5], [0.5]]),
+                           "dA0": numpy.array([[0., 0.], [0., 0.]]),
+                           "dW1": numpy.array([[0., 0.], [0., 0.]]),
+                           "db1": numpy.array([[0.], [0.]])},
+            }
+        ]
+        for test in tests:
+            al = test["al"]
+            y = test["y"]
+            caches = test["caches"]
+            lambd = test["lambd"]
+            expected = test["result"]
+            result = l_model_backward_with_l2(al, y, caches, lambd)
+            for i in range(2):
+                expected["dA" + str(i)] = expected["dA" + str(i)].tolist()
+                expected["dW" + str(i + 1)] = expected["dW" + str(i + 1)].tolist()
+                expected["db" + str(i + 1)] = expected["db" + str(i + 1)].tolist()
+                result["dA" + str(i)] = result["dA" + str(i)].tolist()
+                result["dW" + str(i + 1)] = result["dW" + str(i + 1)].tolist()
+                result["db" + str(i + 1)] = result["db" + str(i + 1)].tolist()
+            self.assertDictEqual(result, expected)
+
+    def test_one_vs_all_prediction(self):
+        """
+        test ml.common.mathEx.one_vs_all_prediction
+        :return:
+        """
+        tests = [
+            {
+                "pm": [[0], [0.1], [0.2]],
+                "result": [[2]],
+            },
+            {
+                "pm": [[0, 1, 2], [0.1, 0.2, 0.3], [0.3, 0.2, 0.1]],
+                "result": [[2, 0, 0]],
+            }
+        ]
+        for test in tests:
+            prob_matrix = test["pm"]
+            expected = test["result"]
+            result = one_vs_all_prediction(numpy.array(prob_matrix))
+            self.assertListEqual(result.tolist(), expected)

--- a/tests/test_common_parameters.py
+++ b/tests/test_common_parameters.py
@@ -90,14 +90,15 @@ class DrDataSvcTests(unittest.TestCase):
         obj = Parameters(self.test_path, 'file name')
         self.assertEqual(obj.base_path, self.test_path)
 
-        tests = [
-            {"grads": {"dW1": numpy.array([[1, 2], [3, 4], [5, 6]]), "db1": numpy.array([[1], [2], [3]])},
-             "learning_rate": 1,
-             "result": {"W1": numpy.array([[0, 0], [0, 0], [0, 0]]), "b1": numpy.array([[0], [0], [0]])}},
-            {"grads": {"dW1": numpy.array([[1, 2], [3, 4], [5, 6]]), "db1": numpy.array([[1], [2], [3]])},
-             "learning_rate": 2,
-             "result": {"W1": numpy.array([[-1, -2], [-3, -4], [-5, -6]]), "b1": numpy.array([[-1], [-2], [-3]])}}
-        ]
+        tests = [{
+            "grads": {"dW1": numpy.array([[1, 2], [3, 4], [5, 6]]), "db1": numpy.array([[1], [2], [3]])},
+            "learning_rate": 1,
+            "result": {"W1": numpy.array([[0, 0], [0, 0], [0, 0]]), "b1": numpy.array([[0], [0], [0]])},
+        }, {
+            "grads": {"dW1": numpy.array([[1, 2], [3, 4], [5, 6]]), "db1": numpy.array([[1], [2], [3]])},
+            "learning_rate": 2,
+            "result": {"W1": numpy.array([[-1, -2], [-3, -4], [-5, -6]]), "b1": numpy.array([[-1], [-2], [-3]])},
+        }]
         for test in tests:
             obj._parameters = {"W1": numpy.array([[1, 2], [3, 4], [5, 6]]), "b1": numpy.array([[1], [2], [3]])}
             grads = test["grads"]
@@ -120,19 +121,16 @@ class DrDataSvcTests(unittest.TestCase):
         obj = Parameters(self.test_path, 'file name')
         self.assertEqual(obj.base_path, self.test_path)
 
-        tests = [
-            {
-                "ld": [1, 2, 3],
-                "parameters": {
+        tests = [{
+            "ld": [1, 2, 3],
+            "parameters": {
                     "W1": [[2.2971712432704137], [-0.8651542170526618]],
                     "b1": [[0.], [0.]],
                     "W2": [[-0.5281717522634557, -1.0729686221561705],
                            [0.8654076293246785, -2.3015386968802827],
                            [1.74481176421648, -0.7612069008951028]],
-                    "b2": [[0.], [0.], [0.]],
-                }
-            }
-        ]
+                    "b2": [[0.], [0.], [0.]]},
+        }]
         for test in tests:
             layer_dims = test["ld"]
             expected_parameters = test["parameters"]

--- a/tests/test_common_parameters.py
+++ b/tests/test_common_parameters.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import unittest
+import numpy
 
 from mock import MagicMock
 from mock import patch
@@ -61,7 +62,7 @@ class DrDataSvcTests(unittest.TestCase):
     @patch('ml.common.parameters.np')
     def test_save(self, mock_np):
         """
-        test ml.common.parameters :: Parameters :: load
+        test ml.common.parameters :: Parameters :: save
         """
         from ml.common.parameters import Parameters
 
@@ -75,3 +76,68 @@ class DrDataSvcTests(unittest.TestCase):
         param_file = os.path.join(self.test_path, 'datasets', 'file name')
         mock_np.save.assert_called_with(param_file, 'params', allow_pickle=True, fix_imports=True)
         pass
+
+    def test_update(self):
+        """
+        test ml.common.parameters :: Parameters :: update
+        :return:
+        """
+        from ml.common.parameters import Parameters
+
+        obj = Parameters('does not exist')
+        self.assertEqual(obj.base_path, self.base_path)
+
+        obj = Parameters(self.test_path, 'file name')
+        self.assertEqual(obj.base_path, self.test_path)
+
+        tests = [
+            {"grads": {"dW1": numpy.array([[1, 2], [3, 4], [5, 6]]), "db1": numpy.array([[1], [2], [3]])},
+             "learning_rate": 1,
+             "result": {"W1": numpy.array([[0, 0], [0, 0], [0, 0]]), "b1": numpy.array([[0], [0], [0]])}},
+            {"grads": {"dW1": numpy.array([[1, 2], [3, 4], [5, 6]]), "db1": numpy.array([[1], [2], [3]])},
+             "learning_rate": 2,
+             "result": {"W1": numpy.array([[-1, -2], [-3, -4], [-5, -6]]), "b1": numpy.array([[-1], [-2], [-3]])}}
+        ]
+        for test in tests:
+            obj._parameters = {"W1": numpy.array([[1, 2], [3, 4], [5, 6]]), "b1": numpy.array([[1], [2], [3]])}
+            grads = test["grads"]
+            learning_rate = test["learning_rate"]
+            expected = test["result"]
+            obj.update(grads, learning_rate)
+            self.assertListEqual(obj._parameters["W1"].tolist(), expected["W1"].tolist())
+            self.assertListEqual(obj._parameters["b1"].tolist(), expected["b1"].tolist())
+
+    def test_initialize_parameters_deep_he(self):
+        """
+        test ml.common.parameters :: Parameters :: initialize_parameters_deep_he
+        :return:
+        """
+        from ml.common.parameters import Parameters
+
+        obj = Parameters('does not exist')
+        self.assertEqual(obj.base_path, self.base_path)
+
+        obj = Parameters(self.test_path, 'file name')
+        self.assertEqual(obj.base_path, self.test_path)
+
+        tests = [
+            {
+                "ld": [1, 2, 3],
+                "parameters": {
+                    "W1": [[2.2971712432704137], [-0.8651542170526618]],
+                    "b1": [[0.], [0.]],
+                    "W2": [[-0.5281717522634557, -1.0729686221561705],
+                           [0.8654076293246785, -2.3015386968802827],
+                           [1.74481176421648, -0.7612069008951028]],
+                    "b2": [[0.], [0.], [0.]],
+                }
+            }
+        ]
+        for test in tests:
+            layer_dims = test["ld"]
+            expected_parameters = test["parameters"]
+            obj.initialize_parameters_deep_he(layer_dims)
+            for i in range(2):
+                obj._parameters["W" + str(i + 1)] = obj._parameters["W" + str(i + 1)].tolist()
+                obj._parameters["b" + str(i + 1)] = obj._parameters["b" + str(i + 1)].tolist()
+            self.assertDictEqual(obj._parameters, expected_parameters)

--- a/tests/test_misc_interview.py
+++ b/tests/test_misc_interview.py
@@ -1,0 +1,73 @@
+"""
+# test_misc_interview.py
+
+"""
+import logging
+import os
+import unittest
+import sys
+
+from ml.utils.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+class InterviewTests(unittest.TestCase):
+    """
+    InterviewTests includes all unit tests for ml.misc.interview module
+    """
+    @classmethod
+    def teardown_class(cls):
+        logging.shutdown()
+
+    def setUp(self):
+        """setup for test"""
+        self.test_path = os.path.dirname(os.path.realpath(__file__))
+        self.repo_path = os.path.dirname(self.test_path)
+        self.proj_path = os.path.join(self.repo_path, "ml")
+        self.base_path = os.path.join(self.repo_path, "ml", "misc")
+        self.data_path = os.path.join(self.repo_path, "ml", "misc", "datasets")
+        pass
+
+    def tearDown(self):
+        """tearing down at the end of the test"""
+        pass
+
+    def test_get_2nd_largest(self):
+        """
+        test ml.misc.interview.get_2nd_largest
+        :return:
+        """
+        from ml.misc.interview import get_2nd_largest
+
+        smallest_num = -sys.maxsize
+        tests = [{
+            "result": 15, "input": [11, 3, 26, 15],  # positive tests and branch checks
+        }, {
+            "result": 999, "input": [19, 998, 999, 1324, 899, 16, 0],
+        }, {
+            "result": 0, "input": [18, -2, 0, -1.2, -999],
+        }, {
+            "result": -1.5, "input": [-2, 0, -1.5],
+        }, {
+            "result": -9999.5, "input": [-9999.5, -9999.5]
+        }, {
+            "result": None, "input": [2],  # negative tests and type checks and branch checks
+        }, {
+            "result": None, "input": 'string',
+        }, {
+            "result": None, "input": [-9999, 'string'],
+        }, {
+            "result": None, "input": [1, '101', '200'],
+        }, {
+            "result": smallest_num, "input": [smallest_num, smallest_num],  # edge tests
+        }, {
+            "result": -9223372036854775808, "input": [0, smallest_num-2, smallest_num-1]
+        }]
+        for test in tests:
+            input_list = test["input"]
+            expected = test["result"]
+            result = get_2nd_largest(input_list)
+            print(result)
+            assert (result == expected)
+            print("passed", test)


### PR DESCRIPTION
This PR includes:
* Adding mathEx.py with tests

Test result:
```
---------- coverage: platform darwin, python 3.7.2-final-0 -----------
Name                             Stmts   Miss     Cover   Missing
-----------------------------------------------------------------
ml/__init__.py                       0      0   100.00%
ml/classifier/__init__.py            0      0   100.00%
ml/classifier/datasvc.py            23      0   100.00%
ml/common/__init__.py                0      0   100.00%
ml/common/api.py                    63      1    98.41%   107
ml/common/datasvc_abstract.py       27      2    92.59%   32-33
ml/common/mathEx.py                164      0   100.00%
ml/common/message_tasker.py         57      0   100.00%
ml/common/parameters.py             32      0   100.00%
ml/common/svc_checker.py           163      0   100.00%
ml/config.py                        88      6    93.18%   86-98
ml/digit_recognizer/datasvc.py      24      0   100.00%
ml/main.py                           6      0   100.00%
ml/utils/__init__.py                 0      0   100.00%
ml/utils/domain_trie.py             50      0   100.00%
ml/utils/extension.py              102      0   100.00%
ml/utils/logger.py                  44      0   100.00%
ml/utils/logger_formatter.py        54      0   100.00%
-----------------------------------------------------------------
TOTAL                              897      9    99.00%
Coverage HTML written to dir htmlcov

Required test coverage of 95% reached. Total coverage: 99.00%

================================= 89 passed, 30 skipped, 2 deselected in 2.50 seconds ==================================

```