### PR TITLE
Modifing stack.py and queue.py with tests

### DIFF
--- a/ml/misc/interview.py
+++ b/ml/misc/interview.py
@@ -55,38 +55,36 @@ def get_fibonacci(n):
     return result
 
 
-def parseNumber(input_string, parsing_hex=False):
+def parse_number(input_string, parsing_hex=False):
     """
     # hex: ABCDEF
-    # atoi (int), integer/float
-    @param input_string:
-    @param parsing_hex:
+    # atoi (int, float), integer/float
+    @param input_string: input string
+    @param parsing_hex: ABCDEF
     @return:
     """
-    if not isinstance(input_string, str):
-        if isinstance(input_string, (int, float)):
-            return input_string
-        return None
-    input_string = input_string.strip()
-    if not len(input_string) > 0:
-        return None
-    if input_string == '-' or input_string == '+':
-        return None
-    result, sign = 0, 1
-    if input_string[0] == '-':
-        sign = -1
-        input_string = input_string[1:]
-    elif input_string[0] == '+':
-        input_string = input_string[1:]
-    if not '0' <= input_string[0] <= '9':
-        return None
-    for char in input_string:
-        if '0' <= char <= '9':
-            result = 10*result + ord(char) - ord('0')
-        else:
-            break
-    # print(result)
-    return sign*result
+    input_string = str(input_string).strip().strip('+').rstrip('.')
+    result, multiplier, division = 0, 10, 1
+    sign = -1 if input_string and input_string[0] == '-' else 1
+    if sign == -1:
+        input_string = input_string.strip('-')
+    for item in input_string:
+        # print('ch:', item)
+        if item == '.':
+            if division > 1:
+                return None
+            multiplier, division = 1, 10
+        elif item < '0' or item > '9':
+            return None
+        elif item >= '0' and item <= '9':
+            v = ord(item) - ord('0')
+            div = v / division if division > 1 else v
+            result = result * multiplier + div
+            # print(s, v, result)
+            if division != 1:
+                division *= 10
+
+    return None if input_string == '' else result * sign
 
 
 def find_largest_in_array(input_array):

--- a/ml/misc/queue.py
+++ b/ml/misc/queue.py
@@ -1,0 +1,87 @@
+"""
+ml/misc/queue
+"""
+
+
+class Queue:
+    """
+    Queue modulo using list
+    """
+
+    def __init__(self, init_list=[]):
+        """
+        initiator of Queue modulo
+        """
+        if not isinstance(init_list, list):
+            self.queue = []
+        else:
+            self.queue = init_list
+
+    def dequeue(self):
+        """
+        pop the first-in item in self.head
+        @return: first-in item
+        """
+        if len(self.queue) > 0:
+            return self.queue.pop()
+        return None
+
+    def enqueue(self, input_item):
+        """
+        add the last-in item in self.head
+        @return:
+        """
+        self.queue.insert(0, input_item)
+
+    def is_empty(self):
+        """
+        check if self.head is empty
+        @return: boolean
+        """
+        return self.queue == []
+
+    def peek(self):
+        if not self.queue:
+            return None
+        return self.queue[-1]
+
+
+class StackQueue:
+    """
+    Queue class with Stack
+    """
+
+    def __init__(self):
+        from ml.misc.stack import Stack
+
+        self.s1 = Stack([])
+        self.s2 = Stack([])
+
+    def _move(self, src, dst):
+        if src.is_empty():
+            return
+        item = src.pop()
+        self._move(src, dst)
+        dst.push(item)
+
+    def dequeue(self):
+        return self.s1.pop()
+
+    def enqueue(self, item):
+        self.s2.push(item)
+        self._move(self.s1, self.s2)
+        self.s1, self.s2 = self.s2, self.s1
+        return item
+
+    def from_list(self, input_list=[]):
+        """
+        form the q.stack with input list
+        @return:
+        """
+        if not isinstance(input_list, list):
+            input_list = []
+        for item in input_list:
+            self.enqueue(item)
+
+    def peek(self):
+        return self.s1.peek()

--- a/ml/misc/stack.py
+++ b/ml/misc/stack.py
@@ -1,0 +1,87 @@
+"""
+ml/misc/stack
+"""
+
+
+class Stack:
+    """
+    Stack modulo using list
+    """
+
+    def __init__(self, init_list=[]):
+        """
+        Initiator of Stack
+        """
+        if not isinstance(init_list, list):
+            self.stack = []
+        else:
+            self.stack = init_list
+        pass
+
+    def is_empty(self):
+        """
+        check if self.head is empty
+        @return: Boolean
+        """
+        return self.stack == []
+
+    def peek(self):
+        """
+        give the last pushed item
+        @return: last pushed item
+        """
+        if not self.stack:
+            return None
+        return self.stack[-1]
+
+    def pop(self):
+        """
+        pop the last pushed item from self.head
+        @return: popped item
+        """
+        if len(self.stack) > 0:
+            return self.stack.pop()
+        return None
+
+    def push(self, input_item):
+        """
+        push the input_item to self.head
+        @return:
+        """
+        self.stack.append(input_item)
+
+
+class QueueStack:
+    """
+    Stack class with Queue
+    """
+
+    def __init__(self):
+        from ml.misc.queue import Queue
+
+        self.q1 = Queue([])
+        self.q2 = Queue([])
+        self.temp = Queue([])
+    pass
+
+    def from_list(self, input_list=[]):
+        """
+        form the q.stack with input list
+        @return:
+        """
+        if not isinstance(input_list, list):
+            input_list = []
+        for item in input_list:
+            self.push(item)
+
+    def peek(self):
+        return self.q1.peek()
+
+    def pop(self):
+        return self.q1.dequeue()
+
+    def push(self, item):
+        self.q2.enqueue(item)
+        while not self.q1.is_empty():
+            self.q2.enqueue(self.q1.dequeue())
+        self.q1, self.q2 = self.q2, self.q1

--- a/ml/misc/timeline.md
+++ b/ml/misc/timeline.md
@@ -1,0 +1,70 @@
+# Interview Timeline
+
+> Agile-like stories for interview preparation.
+> Interview data: 4/22/2019(est.). Start data: 3/24/2019
+> 27 days
+
+
+
+## Content
+
+* [Data Structures](#epic-dstr)
+* [Interview Basics](#epic-ibas)
+* [Reviews](#epic-re)
+* [Project Structure](#epic-pro)
+
+
+
+## Data Structure
+
+### Stack
+
+  * Estimate: 2d
+
+### Queus
+  * Estimate: 2d
+
+### Hash
+  * Estimate: 2d
+
+### Tree
+  * Estimate: 5d
+
+
+
+<br/><a name = "epic-ibas"></a>
+## Interview Basics
+
+  * Phone Interview Simulation: 3d
+  * Software principle: 2d
+  * Testing: 2d
+  * Interview Summary: 2d
+  * IQ tests: 1d
+  * Security questions: 2d
+
+
+
+<br/><a name = "epic-pro"></a>
+## Project Structure
+
+  * Makefile: 1d
+  * Dockerfile: 1d
+  * Bash scripting: 1d
+
+
+
+<br/><a name = "epic-re"></a>
+## Reviews
+
+### Data Structures
+  * Estimate: 1d
+
+### Interview Basics
+  * Estimate: 1d
+
+### complete Interview
+  * Estimate: 2d
+
+
+
+

--- a/tests/test_misc_interview.py
+++ b/tests/test_misc_interview.py
@@ -102,28 +102,30 @@ class InterviewTests(unittest.TestCase):
             result = get_fibonacci(n)
             self.assertEqual(result, expected)
 
-    def test_parseNumber(self):
+    def test_parse_number(self):
         """
         test ml.misc.interview.parseNumber
         @return:
         """
-        from ml.misc.interview import parseNumber
+        from ml.misc.interview import parse_number
         tests = [{
-            "result": 99, "in": '               99string    ',
+            "result": 0, "in": '   0    ',
         }, {
-            "result": 3838438, "in": '3838438sanba   ',
+            "result": None, "in": '               99string    ',
         }, {
-            "result": 3, "in": '     3.1415926',
+            "result": None, "in": '3838438sanba   ',
         }, {
-            "result": -57, "in": '-57perfectstring   ',
+            "result": 3.1415926, "in": '     3.1415926',
         }, {
-            "result": +789, "in": '   +789uuueeexddd  ',
+            "result": None, "in": '-57perfectstring   ',
+        }, {
+            "result": None, "in": '   +789uuueeexddd  ',
         }, {
             "result": None, "in": '   abcd998     ',
         }, {
-            "result": 96, "in": 96
+            "result": 96, "in": '96'
         }, {
-            "result": 9.89, "in": 9.89,
+            "result": 9.89, "in": '9.89',
         }, {
             "result": None, "in": ['3', '4', 'ade', 'lol', 'dota2'],
         }, {
@@ -136,12 +138,17 @@ class InterviewTests(unittest.TestCase):
             "result": None, "in": '+',
         }, {
             "result": None, "in": "-",
+        }, {
+            "result": None, "in": '3.14.15926'
         }]
         for test in tests:
             input_string = test['in']
             expected = test['result']
-            result = parseNumber(input_string)
-            self.assertEqual(result, expected)
+            result = parse_number(input_string)
+            if isinstance(result, float):
+                self.assertTrue(abs(result - expected) < .0000001)
+            else:
+                self.assertEqual(result, expected)
 
     def test_find_largest_in_array(self):
         """

--- a/tests/test_misc_queue.py
+++ b/tests/test_misc_queue.py
@@ -1,0 +1,245 @@
+"""
+# test_misc_queue.py
+
+"""
+import logging
+import os
+import unittest
+import sys
+
+from ml.utils.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+class QueueTests(unittest.TestCase):
+    """
+    QueueTests includes all unit tests for ml.misc.queue module except StackQueue
+    """
+    @classmethod
+    def teardown_class(cls):
+        logging.shutdown()
+
+    def setUp(self):
+        """setup for test"""
+        self.test_path = os.path.dirname(os.path.realpath(__file__))
+        self.repo_path = os.path.dirname(self.test_path)
+        self.proj_path = os.path.join(self.repo_path, "ml")
+        self.base_path = os.path.join(self.repo_path, "ml", "misc")
+        self.data_path = os.path.join(self.repo_path, "ml", "misc", "datasets")
+        pass
+
+    def tearDown(self):
+        """tearing down at the end of the test"""
+        pass
+
+    def test_dequeue(self):
+        """
+        test.ml.misc.queue :: Queue :: dequeue
+        test.ml.misc.queue :: StackQueue :: dequeue
+        @return:
+        """
+        from ml.misc.queue import Queue, StackQueue
+        tests = [{
+            "list": [3, -4.5, 0, sys.maxsize, -sys.maxsize],
+            "head": [3, -4.5, 0, sys.maxsize],
+            "result": -sys.maxsize,
+        }, {
+            "list": ['string', 3001, 'string2', int],
+            "head": ['string', 3001, 'string2'],
+            "result": int,
+        }, {
+            "list": [{'type': dict}],
+            "head": [],
+            "result": {'type': dict},
+
+        }, {
+            "list": [],
+            "head": [],
+            "result": None,
+        }, {
+            "list": 3,
+            "head": [],
+            "result": None,
+        }, {
+            "list": 7.7,
+            "head": [],
+            "result": None,
+        }, {
+            "list": float,
+            "head": [],
+            "result": None,
+        }, {
+            "list": {'string': [dict]},
+            "head": [],
+            "result": None,
+        }, {
+            "list": None,
+            "head": [],
+            "result": None,
+        }]
+        for test in tests:
+            if isinstance(test["list"], list):
+                init_list = test["list"].copy()
+            else:
+                init_list = test["list"]
+            expected_head = test["head"]
+            expected = test["result"]
+            obj = Queue(init_list)
+            result = obj.dequeue()
+            self.assertListEqual(obj.queue, expected_head)  # test Queue
+            self.assertEqual(result, expected)
+            if isinstance(test["list"], list):
+                init_list_2 = test["list"].copy()
+                init_list_2.reverse()
+            else:
+                init_list_2 = test["list"]
+            obj_2 = StackQueue()
+            obj_2.from_list(init_list_2)
+            result_2 = obj_2.dequeue()
+            self.assertListEqual(obj_2.s1.stack, expected_head)  # test StackQueue
+            self.assertEqual(result_2, expected)
+
+    def test_enqueue(self):
+        """
+        test.ml.misc.queue :: Queue :: enqueue
+        test.ml.misc.queue :: StackQueue :: enqueue
+        @return:
+        """
+        from ml.misc.queue import Queue, StackQueue
+        tests = [{
+            "list": [8, 8.8, 0, sys.maxsize, -sys.maxsize, 'string'],
+            "input": ['list string'],
+            "head": [['list string'], 8, 8.8, 0, sys.maxsize, -sys.maxsize, 'string'],
+        }, {
+            "list": [7.7, 0, -11],
+            "input": int,
+            "head": [int, 7.7, 0, -11],
+        }, {
+            "list": [0],
+            "input": 0.0,
+            "head": [0.0, 0],
+        }, {
+            "list": [],
+            "input": 'string',
+            "head": ['string'],
+        }, {
+            "list": 3,
+            "input": 5,
+            "head": [5],
+        }, {
+            "list": 99.8,
+            "input": 3.14,
+            "head": [3.14],
+        }, {
+            "list": 'string',
+            "input": None,
+            "head": [None],
+        }, {
+            "list": float,
+            "input": 'string',
+            "head": ['string'],
+        }, {
+            "list": None,
+            "input": None,
+            "head": [None],
+        }]
+        for test in tests:
+            if isinstance(test["list"], list):
+                init_list = test["list"].copy()
+            else:
+                init_list = test["list"]
+            input_item = test["input"]
+            expected_head = test["head"]
+            obj = Queue(init_list)
+            obj.enqueue(input_item)
+            self.assertEqual(obj.queue, expected_head)  # test Queue
+            if isinstance(test["list"], list):
+                init_list_2 = test["list"].copy()
+                init_list_2.reverse()
+            else:
+                init_list_2 = test["list"]
+            obj_2 = StackQueue()
+            obj_2.from_list(init_list_2)
+            obj_2.enqueue(input_item)
+            self.assertEqual(obj_2.s1.stack, expected_head)
+
+    def test_is_empty(self):
+        """
+        test.ml.misc.queue :: Queue :: is_empty
+        @return:
+        """
+        from ml.misc.queue import Queue
+        tests = [{
+            "head": [], "result": True,
+        }, {
+            "head": [199], "result": False,
+        }, {
+            "head": ['string'], "result": False,
+        }, {
+            "head": [73234, -3.1415926, 0, sys.maxsize, -sys.maxsize], "result": False,
+        }, {
+            "head": 0, "result": False
+        }, {
+            "head": 0.0, "result": False
+        }, {
+            "head": 'string', "result": False,
+        }, {
+            "head": dict, "result": False
+        }, {
+            "head": {}, "result": False,
+        }, {
+            "head": None, "result": False,
+        }]
+        for test in tests:
+            head = test["head"]
+            expected = test["result"]
+            obj = Queue()
+            obj.queue = head
+            result = obj.is_empty()
+            self.assertEqual(result, expected)
+
+    def test_peek(self):
+        """
+        test ml.misc.queue :: Queue :: peek
+        test ml.misc.queue :: StackQueue :: peek
+        @return:
+        """
+        from ml.misc.queue import Queue, StackQueue
+        tests = [{
+            "input": [6, 77, 789, -5, 99.8], "result": 99.8,
+        }, {
+            "input": [[1, 32], 'string', 'string2', -3.14159, int, {'data': float}],
+            "result": {'data': float},
+        }, {
+            "input": [sys.maxsize], "result": sys.maxsize,
+        }, {
+            "input": [-sys.maxsize], "result": -sys.maxsize,
+        }, {
+            "input": [0, 0.0], "result": 0.0,
+        }, {
+            "input": [], "result": None,
+        }, {
+            "input": 8, "result": None,
+        }, {
+            "input": int, "result": None,
+        }, {
+            "input": {'data': 132, 'None': None}, "result": None,
+        }, {
+            "input": 8.9, "result": None,
+        }, {
+            "input": 'string', "result": None,
+        }]
+        for test in tests:
+            init_list = test["input"]
+            expected = test["result"]
+            obj = Queue(init_list)
+            result = obj.peek()
+            self.assertEqual(result, expected)  # test Queue
+            init_list_2 = test["input"]
+            if isinstance(init_list_2, list):
+                init_list_2.reverse()
+            obj_2 = StackQueue()
+            obj_2.from_list(init_list_2)
+            result_2 = obj_2.peek()
+            self.assertEqual(result_2, expected)  # test StackQueue

--- a/tests/test_misc_stack.py
+++ b/tests/test_misc_stack.py
@@ -1,0 +1,285 @@
+"""
+# test_misc_stack.py
+
+"""
+import logging
+import os
+import unittest
+import sys
+
+from ml.utils.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+class StackTests(unittest.TestCase):
+    """
+    StackTests includes all unit tests for ml.misc.stack module
+    """
+    @classmethod
+    def teardown_class(cls):
+        logging.shutdown()
+
+    def setUp(self):
+        """setup for test"""
+        self.test_path = os.path.dirname(os.path.realpath(__file__))
+        self.repo_path = os.path.dirname(self.test_path)
+        self.proj_path = os.path.join(self.repo_path, "ml")
+        self.base_path = os.path.join(self.repo_path, "ml", "misc")
+        self.data_path = os.path.join(self.repo_path, "ml", "misc", "datasets")
+        pass
+
+    def tearDown(self):
+        """tearing down at the end of the test"""
+        pass
+
+    def test__init__(self):
+        """
+        test.ml.misc.stack :: Stack :: __init__
+        @return:
+        """
+        from ml.misc.stack import Stack
+        tests = [{
+            "input": [6, 77, 789, -5, 99.8], "head": [6, 77, 789, -5, 99.8],
+        }, {
+            "input": [[1, 32], 'string', 'string2', -3.14159, int, {'data': float}],
+            "head": [[1, 32], 'string', 'string2', -3.14159, int, {'data': float}],
+        }, {
+            "input": [sys.maxsize], "head": [sys.maxsize],
+        }, {
+            "input": [-sys.maxsize], "head": [-sys.maxsize],
+        }, {
+            "input": [0, 0.0], "head": [0, 0.0],
+        }, {
+            "input": [], "head": [],
+        }, {
+            "input": 8, "head": [],
+        }, {
+            "input": int, "head": [],
+        }, {
+            "input": {'data': 132, 'None': None}, "head": [],
+        }, {
+            "input": 8.9, "head": [],
+        }, {
+            "input": 'string', "head": [],
+        }]
+        for test in tests:
+            init_list = test["input"]
+            expected_head = test["head"]
+            obj = Stack(init_list)
+            self.assertEqual(obj.stack, expected_head)
+
+    def test_is_empty(self):
+        """
+        test ml.misc.stack :: Stack :: is_empty
+        @return:
+        """
+        from ml.misc.stack import Stack
+        tests = [{
+            "head": [], "result": True,
+        }, {
+            "head": [99], "result": False,
+        }, {
+            "head": ['string'], "result": False,
+        }, {
+            "head": [64, -99.343, 0, sys.maxsize, -sys.maxsize], "result": False,
+        }, {
+            "head": 0, "result": False
+        }, {
+            "head": 'string', "result": False,
+        }, {
+            "head": float, "result": False
+        }, {
+            "head": {}, "result": False,
+        }, {
+            "head": None, "result": False,
+        }]
+        for test in tests:
+            head = test["head"]
+            expected = test["result"]
+            obj = Stack()
+            obj.stack = head
+            result = obj.is_empty()
+            self.assertEqual(result, expected)
+
+    def test_peek(self):
+        """
+        test ml.misc.stack :: Stack :: peek
+        test ml.misc.stack :: QueueStack :: peek
+        @return:
+        """
+        from ml.misc.stack import Stack, QueueStack
+        tests = [{
+            "input": [6, 77, 789, -5, 99.8], "result": 99.8,
+        }, {
+            "input": [[1, 32], 'string', 'string2', -3.14159, int, {'data': float}],
+            "result": {'data': float},
+        }, {
+            "input": [sys.maxsize], "result": sys.maxsize,
+        }, {
+            "input": [-sys.maxsize], "result": -sys.maxsize,
+        }, {
+            "input": [0, 0.0], "result": 0.0,
+        }, {
+            "input": [], "result": None,
+        }, {
+            "input": 8, "result": None,
+        }, {
+            "input": int, "result": None,
+        }, {
+            "input": {'data': 132, 'None': None}, "result": None,
+        }, {
+            "input": 8.9, "result": None,
+        }, {
+            "input": 'string', "result": None,
+        }]
+        for test in tests:
+            init_list = test["input"]
+            expected = test["result"]
+            obj = Stack(init_list)
+            result = obj.peek()
+            self.assertEqual(result, expected)  # test Stack
+            obj_2 = QueueStack()
+            obj_2.from_list(init_list)
+            result_2 = obj_2.peek()
+            self.assertEqual(result_2, expected)  # test QueueStack
+
+    def test_pop(self):
+        """
+        test.ml.misc.stack :: Stack :: pop
+        test.ml.misc.stack :: QueueStack :: pop
+        @return:
+        """
+        from ml.misc.stack import Stack, QueueStack
+        tests = [{
+            "input": [3, 3.7, 56.98, -934, 0.765],
+            "head": [3, 3.7, 56.98, -934],
+            "result": 0.765,
+        }, {
+            "input": [1995, 'string', 0],
+            "head": [1995, 'string'],
+            "result": 0
+        }, {
+            "input": [3761],
+            "head": [],
+            "result": 3761,
+        }, {
+            "input": [],
+            "head": [],
+            "result": None,
+        }, {
+            "input": 'string',
+            "head": [],
+            "result": None,
+        }, {
+            "input": -12.3,
+            "head": [],
+            "result": None,
+        }, {
+            "input": int,
+            "head": [],
+            "result": None,
+        }]
+        for test in tests:
+            if isinstance(test["input"], list):
+                init_list = test["input"].copy()
+            else:
+                init_list = test["input"]
+            expected_head = test["head"]
+            expected = test["result"]
+            obj = Stack(init_list)
+            result = obj.pop()
+            self.assertListEqual(obj.stack, expected_head)  # test Stack
+            self.assertEqual(result, expected)
+            if isinstance(test["input"], list):
+                init_list_2 = test["input"].copy()
+            else:
+                init_list_2 = test["input"]
+            obj_2 = QueueStack()
+            obj_2.from_list(init_list_2)
+            result_2 = obj_2.pop()
+            self.assertListEqual(obj_2.q1.queue, expected_head)  # test QueueStack
+            self.assertEqual(result_2, expected)
+
+    def test_push(self):
+        """
+        ml.misc.stack :: Stack :: push
+        ml.misc.stack :: StackQueue :: push
+        @return:
+        """
+        from ml.misc.stack import Stack, QueueStack
+        tests = [{
+            "list": [1314, 732, -sys.maxsize, 99.8],
+            "input": 0.0,
+            "head": [1314, 732, -sys.maxsize, 99.8, 0.0],
+        }, {
+            "list": [0.98, 'string'],
+            "input": 0,
+            "head": [0.98, 'string', 0],
+        }, {
+            "list": [7],
+            "input": float,
+            "head": [7, float],
+        }, {
+            "list": [0],
+            "input": 'string',
+            "head": [0, 'string'],
+        }, {
+            "list": [45, 'string'],
+            "input": ['string1', 'string2'],
+            "head": [45, 'string', ['string1', 'string2']],
+        }, {
+            "list": [77],
+            "input": {'data': [0.0, 0]},
+            "head": [77, {'data': [0.0, 0]}],
+        }, {
+            "list": [75.5],
+            "input": None,
+            "head": [75.5, None]
+        }, {
+            "list": [],
+            "input": sys.maxsize,
+            "head": [sys.maxsize],
+        }, {
+            "list": [],
+            "input": -sys.maxsize,
+            "head": [-sys.maxsize]
+        }, {
+            "list": None,
+            "input": 'string',
+            "head": ['string'],
+        }, {
+            "list": float,
+            "input": int,
+            "head": [int],
+        }, {
+            "list": 123,
+            "input": 321,
+            "head": [321],
+        }, {
+            "list": 33.3,
+            "input": None,
+            "head": [None],
+        }, {
+            "list": None,
+            "input": None,
+            "head": [None],
+        }]
+        for test in tests:
+            if isinstance(test["list"], list):
+                init_list = test["list"].copy()
+            else:
+                init_list = test["list"]
+            item = test["input"]
+            expected_head = test["head"]
+            obj = Stack(init_list)
+            obj.push(item)
+            self.assertListEqual(obj.stack, expected_head)  # test Stack
+            if isinstance(test["list"], list):
+                init_list_2 = test["list"].copy()
+            else:
+                init_list_2 = test["list"]
+            obj_2 = QueueStack()
+            obj_2.from_list(init_list_2)
+            obj_2.push(item)
+            self.assertListEqual(obj_2.q1.queue, expected_head)  # test QueueStack\


### PR DESCRIPTION
This PR includes:
Modifing stack.py and queue.py with tests

```
---------- coverage: platform darwin, python 3.7.2-final-0 -----------
Name                             Stmts   Miss     Cover   Missing
-----------------------------------------------------------------
ml/__init__.py                       0      0   100.00%
ml/classifier/__init__.py            0      0   100.00%
ml/classifier/datasvc.py            23      0   100.00%
ml/common/__init__.py                0      0   100.00%
ml/common/api.py                    63      1    98.41%   107
ml/common/datasvc_abstract.py       27      2    92.59%   32-33
ml/common/mathEx.py                164      0   100.00%
ml/common/message_tasker.py         57      0   100.00%
ml/common/parameters.py             32      0   100.00%
ml/common/svc_checker.py           163      0   100.00%
ml/config.py                        88      6    93.18%   86-98
ml/digit_recognizer/datasvc.py      24      0   100.00%
ml/main.py                           6      0   100.00%
ml/misc/interview.py                98      0   100.00%
ml/misc/linked_list.py             142      1    99.30%   195
ml/misc/stack.py                    18      0   100.00%
ml/utils/__init__.py                 0      0   100.00%
ml/utils/domain_trie.py             50      0   100.00%
ml/utils/extension.py              118      0   100.00%
ml/utils/logger.py                  46      0   100.00%
ml/utils/logger_formatter.py        54      0   100.00%
-----------------------------------------------------------------
TOTAL                             1173     10    99.15%
Coverage HTML written to dir htmlcov
```